### PR TITLE
Fix .replit file

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "go"
-run = "go run main.go"
+run = "go run main.go logic.go"


### PR DESCRIPTION
Changing replit run command so that functions in logic.go are included